### PR TITLE
Upgrade to metricq version 2.0

### DIFF
--- a/metricq_source_http/source/main.py
+++ b/metricq_source_http/source/main.py
@@ -11,6 +11,7 @@ import aiohttp
 
 import hostlist
 import metricq
+from metricq import Timedelta
 from metricq.logging import get_logger
 
 NaN = float('nan')
@@ -389,7 +390,7 @@ class HttpSource(metricq.IntervalSource):
 
     @metricq.rpc_handler('config')
     async def _on_config(self, **config):
-        self.period = 1
+        self.period = Timedelta.from_s(1)
         new_conf, metrics = make_conf_and_metrics(
             config['hosts'],
             config.get('interval', 1),

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,14 @@ setup(name='metricq_source_http',
       entry_points='''
       [console_scripts]
       metricq-source-http=metricq_source_http.source:run
-      ''',
-      install_requires=['aiomonitor', 'click', 'click_log', 'metricq', 'aiohttp', 'jsonpath-rw', 'python-hostlist'])
+      """,
+    install_requires=[
+        "aiomonitor",
+        "click",
+        "click_log",
+        "metricq ~= 2.0",
+        "aiohttp",
+        "jsonpath-rw",
+        "python-hostlist",
+    ],
+)


### PR DESCRIPTION
`IntervalSource.period` is now a Timedelta; explicitly set a source period of 1 second.

Other than that, there seem to be no breaking changes that affect this source.  Full upgrading instruction can be found [here](https://metricq.github.io/metricq-python/upgrading.html#x-2-0), in case I missed something.